### PR TITLE
include extracted front matter in token

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,12 +99,13 @@ module.exports = function front_matter_plugin(md, cb) {
     token.markup = state.src.slice(startLine, pos)
     token.block  = true;
     token.map    = [ startLine, pos ];
+    token.meta   = state.src.slice(start_content, start - 1);
 
     state.parentType = old_parent;
     state.lineMax = old_line_max;
     state.line = nextLine + (auto_closed ? 1 : 0);
 
-    cb(state.src.slice(start_content, start - 1))
+    cb(token.meta);
 
     return true;
   }


### PR DESCRIPTION
markdown-it provides token.meta as a namespace for plugins to pass along arbitrary data- this commit makes the fully extracted front matter in the token so authors can extract and use front matter in the scope of the rendering process, vs only having global access.

my use case is to write a custom renderer for front_matter tokens that just takes the fully extracted front matter (without the fences) and includes it in the env namespace used during the lifecycle of the render.

Thanks for the plugin!