### PR TITLE
Fix token.map

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = function front_matter_plugin(md, cb) {
     token.hidden = true;
     token.markup = state.src.slice(startLine, pos)
     token.block  = true;
-    token.map    = [ startLine, pos ];
+    token.map    = [ startLine, nextLine + (auto_closed ? 1 : 0) ];
 
     state.parentType = old_parent;
     state.lineMax = old_line_max;

--- a/test/index.js
+++ b/test/index.js
@@ -107,4 +107,33 @@ describe('Markdown It Front Matter', () => {
 
     assert.equal(foundFrontmatter, 'x: 1\n---');
   });
+
+  it('Should set correct map for front-matter token', () => {
+    {
+      const tokens = md.parse([
+        '----',
+        'x: 1',
+        '---',
+        '# Head'
+      ].join('\n'));
+
+      assert.strictEqual(tokens[0].type, 'front_matter');
+      assert.deepStrictEqual(tokens[0].map, [0, 4]);
+    }
+    {
+      const tokens = md.parse([
+        '----',
+        'title: Associative arrays',
+        'people:',
+        '    name: John Smith',
+        '    age: 33',
+        'morePeople: { name: Grace Jones, age: 21 }',
+        '---',
+        '# Head'
+      ].join('\n'));
+
+      assert.strictEqual(tokens[0].type, 'front_matter');
+      assert.deepStrictEqual(tokens[0].map, [0, 8]);
+    }
+  });
 });


### PR DESCRIPTION
Map on the front-matter token doesn't seem right. For a document like:

~~~md
---
a: b
---

xyz
~~~

I get back `[0, 12]`. Instead it [should be `[startLine, endLine]`](https://markdown-it.github.io/markdown-it/#Token.prototype.map)